### PR TITLE
Fix: Correct local component path for lgtv_uart_external

### DIFF
--- a/lgtv.yaml
+++ b/lgtv.yaml
@@ -10,7 +10,7 @@ esphome:
 external_components:
   - source:
       type: local
-      path: lgtv_uart_external
+      path: components/lgtv_uart_external
 
 wifi:
   ssid: !secret router_ssid


### PR DESCRIPTION
The `external_components` path in `lgtv.yaml` was pointing to `lgtv_uart_external` instead of `components/lgtv_uart_external`.

This change corrects the path to ensure ESPHome can find and load your custom binary sensor component, resolving the "Platform not found" error.