### PR TITLE
Fix ESPHome component loading and compilation for LGTV UART

### DIFF
--- a/components/lgtv_uart_external/__init__.py
+++ b/components/lgtv_uart_external/__init__.py
@@ -1,50 +1,42 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor, uart
-from esphome.const import CONF_ID, CONF_NAME, CONF_UART_ID
+from esphome.const import (
+    CONF_ID, # Used for the ID of the binary sensor component
+    CONF_UART_ID
+    # CONF_NAME will be implicitly handled by BINARY_SENSOR_SCHEMA
+)
 
-# Declare the C++ namespace if your component uses one.
-# If LGTVUARTComponent is in the global namespace, this line can be omitted
-# or adjusted. For simplicity, assuming global or a specific namespace.
-# For this example, let's assume LGTVUARTComponent is in the global namespace
-# or the header handles its namespace context correctly.
-# lgtv_uart_ns = cg.global_ns.namespace('lgtv_uart_ns')
-# LGTVUARTComponent = lgtv_uart_ns.class_('LGTVUARTComponent', cg.Component, uart.UARTDevice, binary_sensor.BinarySensor)
-# Simpler approach if no explicit namespace is defined in the .h for the class itself:
+DEPENDENCIES = ['uart', 'binary_sensor']
+
+# The C++ class that will be our component and binary sensor
 LGTVUARTComponent = cg.global_ns.class_('LGTVUARTComponent', cg.Component, uart.UARTDevice, binary_sensor.BinarySensor)
 
-
-# Define the platform name that will be used in the YAML
-# e.g., binary_sensor: - platform: lgtv_uart
-# For clarity, let's name it 'lgtv_uart_custom_binary_sensor' to avoid potential
-# conflicts if there was ever an official 'lgtv_uart' component.
-# Or more simply, just 'lgtv_uart_external' to match directory. Let's use this.
-PLATFORM_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend({
-    cv.GenerateID(): cv.declare_id(LGTVUARTComponent),
+# CONFIG_SCHEMA for the top-level 'lgtv_uart_external:' component.
+# It directly includes binary_sensor properties (like name, id) because the component itself IS the binary sensor.
+CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend({
+    # cv.GenerateID() is implicitly part of BINARY_SENSOR_SCHEMA for CONF_ID
+    # We need to ensure that the ID declared here is for LGTVUARTComponent
+    cv.GenerateID(CONF_ID): cv.declare_id(LGTVUARTComponent),
     cv.Required(CONF_UART_ID): cv.use_id(uart.UARTComponent),
-    # CONF_NAME is usually handled by BINARY_SENSOR_SCHEMA
-}).extend(cv.COMPONENT_SCHEMA) # Include component essentials like update_interval
+}).extend(cv.COMPONENT_SCHEMA) # Also extend COMPONENT_SCHEMA for component lifecycle methods if needed
+
 
 async def to_code(config):
-    # Get the UART parent
-    parent = await cg.get_variable(config[CONF_UART_ID])
+    # config now holds the data from the top-level 'lgtv_uart_external:' block in YAML
 
-    # Create an instance of the LGTVUARTComponent
-    var = cg.new_Pvariable(config[CONF_ID], parent) # Pass uart_parent to constructor
+    # Get the UART parent component
+    uart_parent = await cg.get_variable(config[CONF_UART_ID])
 
-    # Register it as a component
+    # Create an instance of our LGTVUARTComponent.
+    # The ID for this instance (var.ID) will come from config[CONF_ID],
+    # which is automatically populated by BINARY_SENSOR_SCHEMA.
+    var = cg.new_Pvariable(config[CONF_ID], uart_parent)
+
+    # Register this instance as a general ESPHome component
     await cg.register_component(var, config)
 
-    # Register it as a binary_sensor
+    # Register this instance specifically as a binary_sensor.
+    # The 'config' dictionary already contains all necessary fields (name, id, etc.)
+    # because we extended BINARY_SENSOR_SCHEMA.
     await binary_sensor.register_binary_sensor(var, config)
-
-    # If LGTVUARTComponent.h is in the same directory as component.py,
-    # ESPHome should pick it up automatically.
-    # If it's in a subdirectory, e.g., 'includes', you might need:
-    # cg.add_library('','','local_path_to_includes_dir_if_any')
-    # cg.add_global_includes('lgtv_uart.h') # Or specific path if not auto-detected
-
-    # For this setup, where lgtv_uart.h is in the same dir (lgtv_uart_external),
-    # ESPHome's build system usually adds this directory to include paths.
-    # Explicitly adding the header can ensure it's found.
-    cg.add_global_includes('lgtv_uart.h')

--- a/lgtv.yaml
+++ b/lgtv.yaml
@@ -10,7 +10,7 @@ esphome:
 external_components:
   - source:
       type: local
-      path: components/lgtv_uart_external
+      path: components
 
 wifi:
   ssid: !secret router_ssid
@@ -35,12 +35,11 @@ uart:
   baud_rate: 9600
   tx_pin: D3
   rx_pin: D4
-    
-binary_sensor:
-  - platform: lgtv_uart_external
-    name: "${upper_devicename} Power state"
-    id: power
-    uart_id: uart_bus
+
+lgtv_uart_external:
+  name: "${upper_devicename} Power state"
+  id: power
+  uart_id: uart_bus
 
 switch:
   - platform: template


### PR DESCRIPTION
This change addresses several issues that prevented the LGTV UART external component from being correctly recognized and compiled:

1.  Restructured the component from a simple binary_sensor platform to a full ESPHome component (`lgtv_uart_external`). This involved:
    - Modifying `__init__.py` to use a top-level `CONFIG_SCHEMA` that incorporates `binary_sensor.BINARY_SENSOR_SCHEMA`.
    - Updating `lgtv.yaml` to use the new top-level `lgtv_uart_external:` configuration block. This resolved the initial "Platform not found" error.

2.  Corrected C++ compilation issues:
    - Removed an erroneous `cg.add_global_includes()` call from `__init__.py`.
    - Added `DEPENDENCIES = ['uart', 'binary_sensor']` to `__init__.py`. This was the key fix to ensure the ESPHome build system provided the correct include paths for standard ESPHome headers (like `binary_sensor.h`), resolving "file not found" errors during C++ compilation.
    - Ensured `lgtv_uart.h` uses standard ESPHome conventions for includes and namespaces once dependencies were correctly declared.

The component should now be correctly discovered and compiled by ESPHome.